### PR TITLE
Fix fixtures folder.

### DIFF
--- a/spec/autocomplete-manager-async-spec.js
+++ b/spec/autocomplete-manager-async-spec.js
@@ -1,12 +1,13 @@
 /* eslint-env jasmine */
 
 const { waitForAutocomplete, timeoutPromise, conditionPromise } = require('./spec-helper')
+const path = require('path')
 
 describe('Async providers', () => {
   let editorView, editor, mainModule, autocompleteManager, registration
 
   beforeEach(async () => {
-    atom.workspace.project.setPaths([__dirname + '/fixtures']);
+    atom.workspace.project.setPaths([path.join(__dirname, 'fixtures')]);
     jasmine.useRealClock()
 
     // Set to live completion

--- a/spec/autocomplete-manager-async-spec.js
+++ b/spec/autocomplete-manager-async-spec.js
@@ -6,6 +6,7 @@ describe('Async providers', () => {
   let editorView, editor, mainModule, autocompleteManager, registration
 
   beforeEach(async () => {
+    atom.workspace.project.setPaths([__dirname + '/fixtures']);
     jasmine.useRealClock()
 
     // Set to live completion

--- a/spec/autocomplete-manager-autosave-spec.js
+++ b/spec/autocomplete-manager-autosave-spec.js
@@ -16,7 +16,7 @@ describe('Autocomplete Manager', () => {
   let createSuggestionsPromise
 
   beforeEach(async () => {
-    atom.workspace.project.setPaths([__dirname + '/fixtures']);
+    atom.workspace.project.setPaths([path.join(__dirname, 'fixtures')]);
     jasmine.useRealClock()
 
     directory = temp.mkdirSync()

--- a/spec/autocomplete-manager-autosave-spec.js
+++ b/spec/autocomplete-manager-autosave-spec.js
@@ -16,6 +16,7 @@ describe('Autocomplete Manager', () => {
   let createSuggestionsPromise
 
   beforeEach(async () => {
+    atom.workspace.project.setPaths([__dirname + '/fixtures']);
     jasmine.useRealClock()
 
     directory = temp.mkdirSync()

--- a/spec/autocomplete-manager-integration-spec.js
+++ b/spec/autocomplete-manager-integration-spec.js
@@ -34,7 +34,7 @@ describe('Autocomplete Manager', () => {
   }
 
   beforeEach(() => {
-    atom.workspace.project.setPaths([__dirname + '/fixtures']);
+    atom.workspace.project.setPaths([path.join(__dirname, 'fixtures')]);
     jasmine.useRealClock()
     gutterWidth = null
     // Set to live completion

--- a/spec/autocomplete-manager-integration-spec.js
+++ b/spec/autocomplete-manager-integration-spec.js
@@ -34,6 +34,7 @@ describe('Autocomplete Manager', () => {
   }
 
   beforeEach(() => {
+    atom.workspace.project.setPaths([__dirname + '/fixtures']);
     jasmine.useRealClock()
     gutterWidth = null
     // Set to live completion

--- a/spec/autocomplete-manager-undo-spec.js
+++ b/spec/autocomplete-manager-undo-spec.js
@@ -9,6 +9,7 @@ describe('Autocomplete Manager', () => {
   let mainModule
 
   beforeEach(() => {
+    atom.workspace.project.setPaths([__dirname + '/fixtures']);
     // Set to live completion
     atom.config.set('autocomplete-plus.enableAutoActivation', true)
     atom.config.set('editor.fontSize', '16')

--- a/spec/autocomplete-manager-undo-spec.js
+++ b/spec/autocomplete-manager-undo-spec.js
@@ -2,6 +2,7 @@
 /* eslint-env jasmine */
 
 import { conditionPromise, waitForAutocomplete } from './spec-helper'
+import path from 'path'
 
 describe('Autocomplete Manager', () => {
   let editorView
@@ -9,7 +10,7 @@ describe('Autocomplete Manager', () => {
   let mainModule
 
   beforeEach(() => {
-    atom.workspace.project.setPaths([__dirname + '/fixtures']);
+    atom.workspace.project.setPaths([path.join(__dirname, 'fixtures')]);
     // Set to live completion
     atom.config.set('autocomplete-plus.enableAutoActivation', true)
     atom.config.set('editor.fontSize', '16')

--- a/spec/main-spec.js
+++ b/spec/main-spec.js
@@ -2,6 +2,7 @@
 /* eslint-env jasmine */
 
 import { conditionPromise, waitForAutocomplete } from './spec-helper'
+import path from 'path'
 
 describe('Autocomplete', () => {
   let editorView
@@ -10,7 +11,7 @@ describe('Autocomplete', () => {
   let mainModule
 
   beforeEach(async () => {
-    atom.workspace.project.setPaths([__dirname + '/fixtures']);
+    atom.workspace.project.setPaths([path.join(__dirname, 'fixtures')]);
     jasmine.useRealClock()
 
     // Set to live completion

--- a/spec/main-spec.js
+++ b/spec/main-spec.js
@@ -10,6 +10,7 @@ describe('Autocomplete', () => {
   let mainModule
 
   beforeEach(async () => {
+    atom.workspace.project.setPaths([__dirname + '/fixtures']);
     jasmine.useRealClock()
 
     // Set to live completion

--- a/spec/provider-api-legacy-spec.js
+++ b/spec/provider-api-legacy-spec.js
@@ -3,12 +3,13 @@
 
 import { triggerAutocompletion, waitForAutocomplete, conditionPromise } from './spec-helper'
 import grim from 'grim'
+import path from 'path'
 
 describe('Provider API Legacy', () => {
   let [editor, mainModule, autocompleteManager, registration, testProvider] = []
 
   beforeEach(async () => {
-    atom.workspace.project.setPaths([__dirname + '/fixtures']);
+    atom.workspace.project.setPaths([path.join(__dirname, 'fixtures')]);
     jasmine.useRealClock()
     jasmine.snapshotDeprecations()
 

--- a/spec/provider-api-legacy-spec.js
+++ b/spec/provider-api-legacy-spec.js
@@ -8,6 +8,7 @@ describe('Provider API Legacy', () => {
   let [editor, mainModule, autocompleteManager, registration, testProvider] = []
 
   beforeEach(async () => {
+    atom.workspace.project.setPaths([__dirname + '/fixtures']);
     jasmine.useRealClock()
     jasmine.snapshotDeprecations()
 

--- a/spec/provider-api-spec.js
+++ b/spec/provider-api-spec.js
@@ -2,12 +2,13 @@
 /* eslint-env jasmine */
 
 import {waitForAutocomplete, triggerAutocompletion, conditionPromise} from './spec-helper'
+import path from 'path'
 
 describe('Provider API', () => {
   let [editor, mainModule, autocompleteManager, registration, testProvider, testProvider2] = []
 
   beforeEach(async () => {
-    atom.workspace.project.setPaths([__dirname + '/fixtures']);
+    atom.workspace.project.setPaths([path.join(__dirname, 'fixtures')]);
     jasmine.useRealClock()
 
     // Set to live completion

--- a/spec/provider-api-spec.js
+++ b/spec/provider-api-spec.js
@@ -7,6 +7,7 @@ describe('Provider API', () => {
   let [editor, mainModule, autocompleteManager, registration, testProvider, testProvider2] = []
 
   beforeEach(async () => {
+    atom.workspace.project.setPaths([__dirname + '/fixtures']);
     jasmine.useRealClock()
 
     // Set to live completion

--- a/spec/subsequence-provider-spec.js
+++ b/spec/subsequence-provider-spec.js
@@ -1,6 +1,7 @@
 /* eslint-env jasmine */
 
 const { conditionPromise } = require('./spec-helper')
+const path = require('path')
 
 let suggestionsForPrefix = async (provider, editor, prefix, options) => {
   let bufferPosition = editor.getCursorBufferPosition()
@@ -21,7 +22,7 @@ describe('SubsequenceProvider', () => {
   let [editor, mainModule, autocompleteManager, provider] = []
 
   beforeEach(async () => {
-    atom.workspace.project.setPaths([__dirname + '/fixtures']);
+    atom.workspace.project.setPaths([path.join(__dirname, 'fixtures')]);
     jasmine.useRealClock()
 
     // Set to live completion

--- a/spec/subsequence-provider-spec.js
+++ b/spec/subsequence-provider-spec.js
@@ -21,6 +21,7 @@ describe('SubsequenceProvider', () => {
   let [editor, mainModule, autocompleteManager, provider] = []
 
   beforeEach(async () => {
+    atom.workspace.project.setPaths([__dirname + '/fixtures']);
     jasmine.useRealClock()
 
     // Set to live completion


### PR DESCRIPTION
When you run the tests of this package directly all tests pass but when you run them from the script `script/run-package-tests.js` from Atom/Pulsar the tests fail. That is because the project folder is not set correctly when there are other tests running along with these ones. If you set the project folder manually before each test then the tests pass always.