### PR TITLE
Fix outdated test lib

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,8 +1,1685 @@
 {
   "name": "autocomplete-plus",
-  "version": "2.42.5",
-  "lockfileVersion": 1,
+  "version": "2.42.6",
+  "lockfileVersion": 2,
   "requires": true,
+  "packages": {
+    "": {
+      "name": "autocomplete-plus",
+      "version": "2.42.6",
+      "license": "MIT",
+      "dependencies": {
+        "atom-slick": "^2.0.0",
+        "dompurify": "^2.2.6",
+        "fuzzaldrin": "^2.1.0",
+        "fuzzaldrin-plus": "^0.6.0",
+        "grim": "^2.0.1",
+        "marked": "^4.0.10",
+        "minimatch": "^3.0.3",
+        "selector-kit": "^0.1",
+        "stable": "^0.1.5",
+        "underscore-plus": "^1.6.6"
+      },
+      "devDependencies": {
+        "coffeelint": "^1.9.7",
+        "fs-plus": ">=2.4.0",
+        "standard": "^8.3.0",
+        "temp": ">=0.7.0"
+      },
+      "engines": {
+        "atom": ">=0.189.0 <2.0.0"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "5.7.4",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.4.tgz",
+      "integrity": "sha512-1D++VG7BhrtvQpNbBzovKNc1FLGGEE/oGe7b9xJm/RFHMBeUaUGpluV9RLjZa47YFdPcDAenEYuq9pQPcMdLJg==",
+      "dev": true,
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
+      "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
+      "dev": true,
+      "dependencies": {
+        "acorn": "^3.0.4"
+      }
+    },
+    "node_modules/acorn-jsx/node_modules/acorn": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
+      "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
+      "dev": true,
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "4.11.8",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
+      "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
+      "dev": true,
+      "dependencies": {
+        "co": "^4.6.0",
+        "json-stable-stringify": "^1.0.1"
+      }
+    },
+    "node_modules/ajv-keywords": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-1.5.1.tgz",
+      "integrity": "sha1-MU3QpLM2j609/NxU7eYXG4htrzw=",
+      "dev": true,
+      "peerDependencies": {
+        "ajv": ">=4.10.0"
+      }
+    },
+    "node_modules/ansi-escapes": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
+      "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/async": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+      "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+      "dev": true
+    },
+    "node_modules/atom-slick": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/atom-slick/-/atom-slick-2.0.0.tgz",
+      "integrity": "sha1-/w2+Fb4sTtomi50w124lF+C308o=",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/babel-code-frame": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+      "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^1.1.3",
+        "esutils": "^2.0.2",
+        "js-tokens": "^3.0.2"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+      "dev": true
+    },
+    "node_modules/caller-path": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
+      "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
+      "dev": true,
+      "dependencies": {
+        "callsites": "^0.2.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/callsites": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
+      "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^2.2.1",
+        "escape-string-regexp": "^1.0.2",
+        "has-ansi": "^2.0.0",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/circular-json": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
+      "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
+      "deprecated": "CircularJSON is in maintenance only, flatted is its successor.",
+      "dev": true
+    },
+    "node_modules/cli-cursor": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
+      "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
+      "dev": true,
+      "dependencies": {
+        "restore-cursor": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/cli-width": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
+      "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
+      "dev": true
+    },
+    "node_modules/co": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+      "dev": true,
+      "engines": {
+        "iojs": ">= 1.0.0",
+        "node": ">= 0.12.0"
+      }
+    },
+    "node_modules/code-point-at": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/coffee-script": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.11.1.tgz",
+      "integrity": "sha1-vxxHrWREOg2V0S3ysUfMCk2q1uk=",
+      "deprecated": "CoffeeScript on NPM has moved to \"coffeescript\" (no hyphen)",
+      "dev": true,
+      "bin": {
+        "cake": "bin/cake",
+        "coffee": "bin/coffee"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/coffeelint": {
+      "version": "1.16.2",
+      "resolved": "https://registry.npmjs.org/coffeelint/-/coffeelint-1.16.2.tgz",
+      "integrity": "sha512-6mzgOo4zb17WfdrSui/cSUEgQ0AQkW3gXDht+6lHkfkqGUtSYKwGdGcXsDfAyuScVzTlTtKdfwkAlJWfqul7zg==",
+      "dev": true,
+      "dependencies": {
+        "coffee-script": "~1.11.0",
+        "glob": "^7.0.6",
+        "ignore": "^3.0.9",
+        "optimist": "^0.6.1",
+        "resolve": "^0.6.3",
+        "strip-json-comments": "^1.0.2"
+      },
+      "bin": {
+        "coffeelint": "bin/coffeelint"
+      },
+      "engines": {
+        "node": ">=0.8.0",
+        "npm": ">=1.3.7"
+      }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+    },
+    "node_modules/concat-stream": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+      "dev": true,
+      "engines": [
+        "node >= 0.8"
+      ],
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
+      }
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "dev": true
+    },
+    "node_modules/d": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
+      "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
+      "dev": true,
+      "dependencies": {
+        "es5-ext": "^0.10.9"
+      }
+    },
+    "node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/debug-log": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/debug-log/-/debug-log-1.0.1.tgz",
+      "integrity": "sha1-IwdjLUwEOCuN+KMvcLiVBG1SdF8=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+      "dev": true
+    },
+    "node_modules/deglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/deglob/-/deglob-2.1.1.tgz",
+      "integrity": "sha512-2kjwuGGonL7gWE1XU4Fv79+vVzpoQCl0V+boMwWtOQJV2AGDabCwez++nB1Nli/8BabAfZQ/UuHPlp6AymKdWw==",
+      "dev": true,
+      "dependencies": {
+        "find-root": "^1.0.0",
+        "glob": "^7.0.5",
+        "ignore": "^3.0.9",
+        "pkg-config": "^1.1.0",
+        "run-parallel": "^1.1.2",
+        "uniq": "^1.0.1"
+      }
+    },
+    "node_modules/doctrine": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
+      "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
+      "dev": true,
+      "dependencies": {
+        "esutils": "^2.0.2",
+        "isarray": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/dompurify": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.2.6.tgz",
+      "integrity": "sha512-7b7ZArhhH0SP6W2R9cqK6RjaU82FZ2UPM7RO8qN1b1wyvC/NY1FNWcX1Pu00fFOAnzEORtwXe4bPaClg6pUybQ=="
+    },
+    "node_modules/es5-ext": {
+      "version": "0.10.50",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.50.tgz",
+      "integrity": "sha512-KMzZTPBkeQV/JcSQhI5/z6d9VWJ3EnQ194USTUwIYZ2ZbpN8+SGXQKt1h68EX44+qt+Fzr8DO17vnxrw7c3agw==",
+      "dev": true,
+      "dependencies": {
+        "es6-iterator": "~2.0.3",
+        "es6-symbol": "~3.1.1",
+        "next-tick": "^1.0.0"
+      }
+    },
+    "node_modules/es6-iterator": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
+      "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
+      "dev": true,
+      "dependencies": {
+        "d": "1",
+        "es5-ext": "^0.10.35",
+        "es6-symbol": "^3.1.1"
+      }
+    },
+    "node_modules/es6-map": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.5.tgz",
+      "integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
+      "dev": true,
+      "dependencies": {
+        "d": "1",
+        "es5-ext": "~0.10.14",
+        "es6-iterator": "~2.0.1",
+        "es6-set": "~0.1.5",
+        "es6-symbol": "~3.1.1",
+        "event-emitter": "~0.3.5"
+      }
+    },
+    "node_modules/es6-set": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.5.tgz",
+      "integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
+      "dev": true,
+      "dependencies": {
+        "d": "1",
+        "es5-ext": "~0.10.14",
+        "es6-iterator": "~2.0.1",
+        "es6-symbol": "3.1.1",
+        "event-emitter": "~0.3.5"
+      }
+    },
+    "node_modules/es6-symbol": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
+      "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
+      "dev": true,
+      "dependencies": {
+        "d": "1",
+        "es5-ext": "~0.10.14"
+      }
+    },
+    "node_modules/es6-weak-map": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.3.tgz",
+      "integrity": "sha512-p5um32HOTO1kP+w7PRnB+5lQ43Z6muuMuIMffvDN8ZB4GcnjLBV6zGStpbASIMk4DCAvEaamhe2zhyCb/QXXsA==",
+      "dev": true,
+      "dependencies": {
+        "d": "1",
+        "es5-ext": "^0.10.46",
+        "es6-iterator": "^2.0.3",
+        "es6-symbol": "^3.1.1"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/escope": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
+      "integrity": "sha1-4Bl16BJ4GhY6ba392AOY3GTIicM=",
+      "dev": true,
+      "dependencies": {
+        "es6-map": "^0.1.3",
+        "es6-weak-map": "^2.0.1",
+        "esrecurse": "^4.1.0",
+        "estraverse": "^4.1.1"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/eslint": {
+      "version": "3.10.2",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-3.10.2.tgz",
+      "integrity": "sha1-yaEOi/bp1lZRIEd4xQM0Hx6sPOc=",
+      "dev": true,
+      "dependencies": {
+        "babel-code-frame": "^6.16.0",
+        "chalk": "^1.1.3",
+        "concat-stream": "^1.4.6",
+        "debug": "^2.1.1",
+        "doctrine": "^1.2.2",
+        "escope": "^3.6.0",
+        "espree": "^3.3.1",
+        "estraverse": "^4.2.0",
+        "esutils": "^2.0.2",
+        "file-entry-cache": "^2.0.0",
+        "glob": "^7.0.3",
+        "globals": "^9.2.0",
+        "ignore": "^3.2.0",
+        "imurmurhash": "^0.1.4",
+        "inquirer": "^0.12.0",
+        "is-my-json-valid": "^2.10.0",
+        "is-resolvable": "^1.0.0",
+        "js-yaml": "^3.5.1",
+        "json-stable-stringify": "^1.0.0",
+        "levn": "^0.3.0",
+        "lodash": "^4.0.0",
+        "mkdirp": "^0.5.0",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.8.2",
+        "path-is-inside": "^1.0.1",
+        "pluralize": "^1.2.1",
+        "progress": "^1.1.8",
+        "require-uncached": "^1.0.2",
+        "shelljs": "^0.7.5",
+        "strip-bom": "^3.0.0",
+        "strip-json-comments": "~1.0.1",
+        "table": "^3.7.8",
+        "text-table": "~0.2.0",
+        "user-home": "^2.0.0"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/eslint-config-standard": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-6.2.1.tgz",
+      "integrity": "sha1-06aKr8cZFjnn7kQec0hzkCY1QpI=",
+      "dev": true,
+      "peerDependencies": {
+        "eslint": ">=3.8.1",
+        "eslint-plugin-promise": ">=3.3.0",
+        "eslint-plugin-standard": ">=2.0.0"
+      }
+    },
+    "node_modules/eslint-config-standard-jsx": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-standard-jsx/-/eslint-config-standard-jsx-3.2.0.tgz",
+      "integrity": "sha1-wkDibtkZoRpCqk3oBZRys4Jo1iA=",
+      "dev": true,
+      "peerDependencies": {
+        "eslint": ">=3.0.0",
+        "eslint-plugin-react": ">=2.7.1"
+      }
+    },
+    "node_modules/eslint-plugin-promise": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-3.4.2.tgz",
+      "integrity": "sha1-G+J5Pq/i0YtbEjuBNsJp+AT+cSI=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/eslint-plugin-react": {
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-6.7.1.tgz",
+      "integrity": "sha1-Gvlq6lRYVoJRV9l8G1DVqPtkpac=",
+      "dev": true,
+      "dependencies": {
+        "doctrine": "^1.2.2",
+        "jsx-ast-utils": "^1.3.3"
+      },
+      "engines": {
+        "node": ">=0.10"
+      },
+      "peerDependencies": {
+        "eslint": "^2.0.0 || ^3.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-standard": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-standard/-/eslint-plugin-standard-2.0.1.tgz",
+      "integrity": "sha1-NYlpn/nJF/LCX3apFmh/ZBw2n/M=",
+      "dev": true,
+      "peerDependencies": {
+        "eslint": ">=3.0.0"
+      }
+    },
+    "node_modules/espree": {
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.4.tgz",
+      "integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
+      "dev": true,
+      "dependencies": {
+        "acorn": "^5.5.0",
+        "acorn-jsx": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true,
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
+      "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
+      "dev": true,
+      "dependencies": {
+        "estraverse": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
+      "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/event-emitter": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
+      "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
+      "dev": true,
+      "dependencies": {
+        "d": "1",
+        "es5-ext": "~0.10.14"
+      }
+    },
+    "node_modules/event-kit": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/event-kit/-/event-kit-2.5.3.tgz",
+      "integrity": "sha512-b7Qi1JNzY4BfAYfnIRanLk0DOD1gdkWHT4GISIn8Q2tAf3LpU8SP2CMwWaq40imYoKWbtN4ZhbSRxvsnikooZQ=="
+    },
+    "node_modules/exit-hook": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
+      "integrity": "sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+      "dev": true
+    },
+    "node_modules/figures": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
+      "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
+      "dev": true,
+      "dependencies": {
+        "escape-string-regexp": "^1.0.5",
+        "object-assign": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/file-entry-cache": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
+      "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
+      "dev": true,
+      "dependencies": {
+        "flat-cache": "^1.2.1",
+        "object-assign": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/find-root": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
+      "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==",
+      "dev": true
+    },
+    "node_modules/flat-cache": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.4.tgz",
+      "integrity": "sha512-VwyB3Lkgacfik2vhqR4uv2rvebqmDvFu4jlN/C1RzWoJEo8I7z4Q404oiqYCkq41mni8EzQnm95emU9seckwtg==",
+      "dev": true,
+      "dependencies": {
+        "circular-json": "^0.3.1",
+        "graceful-fs": "^4.1.2",
+        "rimraf": "~2.6.2",
+        "write": "^0.2.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/fs-plus": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/fs-plus/-/fs-plus-3.1.1.tgz",
+      "integrity": "sha512-Se2PJdOWXqos1qVTkvqqjb0CSnfBnwwD+pq+z4ksT+e97mEShod/hrNg0TRCCsXPbJzcIq+NuzQhigunMWMJUA==",
+      "dev": true,
+      "dependencies": {
+        "async": "^1.5.2",
+        "mkdirp": "^0.5.1",
+        "rimraf": "^2.5.2",
+        "underscore-plus": "1.x"
+      }
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "node_modules/fuzzaldrin": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fuzzaldrin/-/fuzzaldrin-2.1.0.tgz",
+      "integrity": "sha1-kCBMPi/appQbso0WZF1BgGOpDps="
+    },
+    "node_modules/fuzzaldrin-plus": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/fuzzaldrin-plus/-/fuzzaldrin-plus-0.6.0.tgz",
+      "integrity": "sha1-gy9kifvodnaUWVmckUpnDsIpR+4="
+    },
+    "node_modules/generate-function": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.3.1.tgz",
+      "integrity": "sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==",
+      "dev": true,
+      "dependencies": {
+        "is-property": "^1.0.2"
+      }
+    },
+    "node_modules/generate-object-property": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+      "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
+      "dev": true,
+      "dependencies": {
+        "is-property": "^1.0.0"
+      }
+    },
+    "node_modules/get-stdin": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-5.0.1.tgz",
+      "integrity": "sha1-Ei4WFZHiH/TFJTAwVpPyDmOTo5g=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/glob": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
+      "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
+      "dev": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/globals": {
+      "version": "9.18.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
+      "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.1.15",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
+      "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
+      "dev": true
+    },
+    "node_modules/grim": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/grim/-/grim-2.0.2.tgz",
+      "integrity": "sha512-Qj7hTJRfd87E/gUgfvM0YIH/g2UA2SV6niv6BYXk1o6w4mhgv+QyYM1EjOJQljvzgEj4SqSsRWldXIeKHz3e3Q==",
+      "dependencies": {
+        "event-kit": "^2.0.0"
+      }
+    },
+    "node_modules/has-ansi": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/home-or-tmp": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
+      "integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
+      "dev": true,
+      "dependencies": {
+        "os-homedir": "^1.0.0",
+        "os-tmpdir": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ignore": {
+      "version": "3.3.10",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.10.tgz",
+      "integrity": "sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug==",
+      "dev": true
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "dev": true
+    },
+    "node_modules/inquirer": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz",
+      "integrity": "sha1-HvK/1jUE3wvHV4X/+MLEHfEvB34=",
+      "dev": true,
+      "dependencies": {
+        "ansi-escapes": "^1.1.0",
+        "ansi-regex": "^2.0.0",
+        "chalk": "^1.0.0",
+        "cli-cursor": "^1.0.1",
+        "cli-width": "^2.0.0",
+        "figures": "^1.3.5",
+        "lodash": "^4.3.0",
+        "readline2": "^1.0.1",
+        "run-async": "^0.1.0",
+        "rx-lite": "^3.1.2",
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.0",
+        "through": "^2.3.6"
+      }
+    },
+    "node_modules/interpret": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.2.0.tgz",
+      "integrity": "sha512-mT34yGKMNceBQUoVn7iCDKDntA7SC6gycMAWzGx1z/CMCTV7b2AAtXlo3nRyHZ1FelRkQbQjprHSYGwzLtkVbw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+      "dev": true,
+      "dependencies": {
+        "number-is-nan": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-my-ip-valid": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-my-ip-valid/-/is-my-ip-valid-1.0.0.tgz",
+      "integrity": "sha512-gmh/eWXROncUzRnIa1Ubrt5b8ep/MGSnfAUI3aRp+sqTCs1tv1Isl8d8F6JmkN3dXKc3ehZMrtiPN9eL03NuaQ==",
+      "dev": true
+    },
+    "node_modules/is-my-json-valid": {
+      "version": "2.20.0",
+      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.20.0.tgz",
+      "integrity": "sha512-XTHBZSIIxNsIsZXg7XB5l8z/OBFosl1Wao4tXLpeC7eKU4Vm/kdop2azkPqULwnfGQjmeDIyey9g7afMMtdWAA==",
+      "dev": true,
+      "dependencies": {
+        "generate-function": "^2.0.0",
+        "generate-object-property": "^1.1.0",
+        "is-my-ip-valid": "^1.0.0",
+        "jsonpointer": "^4.0.0",
+        "xtend": "^4.0.0"
+      }
+    },
+    "node_modules/is-property": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+      "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
+      "dev": true
+    },
+    "node_modules/is-resolvable": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.1.0.tgz",
+      "integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg==",
+      "dev": true
+    },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "dev": true
+    },
+    "node_modules/js-tokens": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+      "dev": true
+    },
+    "node_modules/js-yaml": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+      "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+      "dev": true,
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/json-stable-stringify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+      "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+      "dev": true,
+      "dependencies": {
+        "jsonify": "~0.0.0"
+      }
+    },
+    "node_modules/jsonify": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/jsonpointer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
+      "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/jsx-ast-utils": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-1.4.1.tgz",
+      "integrity": "sha1-OGchPo3Xm/Ho8jAMDPwe+xgsDfE=",
+      "dev": true,
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+      "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+      "dev": true,
+      "dependencies": {
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.19",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
+      "dev": true
+    },
+    "node_modules/marked": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.10.tgz",
+      "integrity": "sha512-+QvuFj0nGgO970fySghXGmuw+Fd0gD2x3+MqCWLIPf5oxdv1Ka6b2q+z9RP01P/IaKPMEramy+7cNy/Lw8c3hw==",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+      "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
+      "dev": true
+    },
+    "node_modules/mkdirp": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+      "dev": true,
+      "dependencies": {
+        "minimist": "^1.2.5"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      }
+    },
+    "node_modules/mkdirp/node_modules/minimist": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "dev": true
+    },
+    "node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "dev": true
+    },
+    "node_modules/mute-stream": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz",
+      "integrity": "sha1-j7+rsKmKJT0xhDMfno3rc3L6xsA=",
+      "dev": true
+    },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+      "dev": true
+    },
+    "node_modules/next-tick": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
+      "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
+      "dev": true
+    },
+    "node_modules/number-is-nan": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/onetime": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+      "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/optimist": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+      "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+      "dev": true,
+      "dependencies": {
+        "minimist": "~0.0.1",
+        "wordwrap": "~0.0.2"
+      }
+    },
+    "node_modules/optionator": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
+      "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
+      "dev": true,
+      "dependencies": {
+        "deep-is": "~0.1.3",
+        "fast-levenshtein": "~2.0.4",
+        "levn": "~0.3.0",
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2",
+        "wordwrap": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/optionator/node_modules/wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+      "dev": true
+    },
+    "node_modules/os-homedir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/os-tmpdir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/path-is-inside": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
+      "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
+      "dev": true
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+      "dev": true
+    },
+    "node_modules/pkg-config": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/pkg-config/-/pkg-config-1.1.1.tgz",
+      "integrity": "sha1-VX7yLXPaPIg3EHdmxS6tq94pj+Q=",
+      "dev": true,
+      "dependencies": {
+        "debug-log": "^1.0.0",
+        "find-root": "^1.0.0",
+        "xtend": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/pluralize": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-1.2.1.tgz",
+      "integrity": "sha1-0aIUg/0iu0HlihL6NCGCMUCJfEU=",
+      "dev": true
+    },
+    "node_modules/prelude-ls": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
+      "dev": true
+    },
+    "node_modules/progress": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
+      "integrity": "sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+      "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+      "dev": true,
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/readline2": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz",
+      "integrity": "sha1-QQWWCP/BVHV7cV2ZidGZ/783LjU=",
+      "dev": true,
+      "dependencies": {
+        "code-point-at": "^1.0.0",
+        "is-fullwidth-code-point": "^1.0.0",
+        "mute-stream": "0.0.5"
+      }
+    },
+    "node_modules/rechoir": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+      "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
+      "dev": true,
+      "dependencies": {
+        "resolve": "^1.1.6"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/rechoir/node_modules/resolve": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.11.1.tgz",
+      "integrity": "sha512-vIpgF6wfuJOZI7KKKSP+HmiKggadPQAdsp5HiC1mvqnfp0gF1vdwgBWZIdrVft9pgqoMFQN+R7BSWZiBxx+BBw==",
+      "dev": true,
+      "dependencies": {
+        "path-parse": "^1.0.6"
+      }
+    },
+    "node_modules/require-uncached": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
+      "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
+      "dev": true,
+      "dependencies": {
+        "caller-path": "^0.1.0",
+        "resolve-from": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resolve": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-0.6.3.tgz",
+      "integrity": "sha1-3ZV5gufnNt699TtYpN2RdUV13UY=",
+      "dev": true
+    },
+    "node_modules/resolve-from": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
+      "integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/restore-cursor": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
+      "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
+      "dev": true,
+      "dependencies": {
+        "exit-hook": "^1.0.0",
+        "onetime": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rimraf": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+      "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+      "dev": true,
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      }
+    },
+    "node_modules/run-async": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
+      "integrity": "sha1-yK1KXhEGYeQCp9IbUw4AnyX444k=",
+      "dev": true,
+      "dependencies": {
+        "once": "^1.3.0"
+      }
+    },
+    "node_modules/run-parallel": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.9.tgz",
+      "integrity": "sha512-DEqnSRTDw/Tc3FXf49zedI638Z9onwUotBMiUFKmrO2sdFKIbXamXGQ3Axd4qgphxKB4kw/qP1w5kTxnfU1B9Q==",
+      "dev": true
+    },
+    "node_modules/rx-lite": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-3.1.2.tgz",
+      "integrity": "sha1-Gc5QLKVyZl87ZHsQk5+X/RYV8QI=",
+      "dev": true
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true
+    },
+    "node_modules/selector-kit": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/selector-kit/-/selector-kit-0.1.0.tgz",
+      "integrity": "sha1-MEM4/OzOo17Cj/rdt5KrdxVjPm8=",
+      "dependencies": {
+        "atom-slick": "^2"
+      }
+    },
+    "node_modules/shelljs": {
+      "version": "0.7.8",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.8.tgz",
+      "integrity": "sha1-3svPh0sNHl+3LhSxZKloMEjprLM=",
+      "dev": true,
+      "dependencies": {
+        "glob": "^7.0.0",
+        "interpret": "^1.0.0",
+        "rechoir": "^0.6.2"
+      },
+      "bin": {
+        "shjs": "bin/shjs"
+      },
+      "engines": {
+        "iojs": "*",
+        "node": ">=0.11.0"
+      }
+    },
+    "node_modules/slice-ansi": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
+      "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "dev": true
+    },
+    "node_modules/stable": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/stable/-/stable-0.1.8.tgz",
+      "integrity": "sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w==",
+      "deprecated": "Modern JS already guarantees Array#sort() is a stable sort, so this library is deprecated. See the compatibility table on MDN: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort#browser_compatibility"
+    },
+    "node_modules/standard": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/standard/-/standard-8.6.0.tgz",
+      "integrity": "sha1-Y1Eyvnv7VnwpIQBfMPnjUOR1Kq0=",
+      "dev": true,
+      "dependencies": {
+        "eslint": "~3.10.2",
+        "eslint-config-standard": "6.2.1",
+        "eslint-config-standard-jsx": "3.2.0",
+        "eslint-plugin-promise": "~3.4.0",
+        "eslint-plugin-react": "~6.7.1",
+        "eslint-plugin-standard": "~2.0.1",
+        "standard-engine": "~5.2.0"
+      },
+      "bin": {
+        "standard": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/standard-engine": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/standard-engine/-/standard-engine-5.2.0.tgz",
+      "integrity": "sha1-QAZgrlrM6K/U22D/IhSpGQrXkKM=",
+      "dev": true,
+      "dependencies": {
+        "deglob": "^2.0.0",
+        "find-root": "^1.0.0",
+        "get-stdin": "^5.0.1",
+        "home-or-tmp": "^2.0.0",
+        "minimist": "^1.1.0",
+        "pkg-config": "^1.0.1"
+      }
+    },
+    "node_modules/standard-engine/node_modules/minimist": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "dev": true
+    },
+    "node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+      "dev": true,
+      "dependencies": {
+        "code-point-at": "^1.0.0",
+        "is-fullwidth-code-point": "^1.0.0",
+        "strip-ansi": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/strip-bom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
+      "integrity": "sha1-HhX7ysl9Pumb8tc7TGVrCCu6+5E=",
+      "dev": true,
+      "bin": {
+        "strip-json-comments": "cli.js"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/table": {
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/table/-/table-3.8.3.tgz",
+      "integrity": "sha1-K7xULw/amGGnVdOUf+/Ys/UThV8=",
+      "dev": true,
+      "dependencies": {
+        "ajv": "^4.7.0",
+        "ajv-keywords": "^1.0.0",
+        "chalk": "^1.1.1",
+        "lodash": "^4.0.0",
+        "slice-ansi": "0.0.4",
+        "string-width": "^2.0.0"
+      }
+    },
+    "node_modules/table/node_modules/ansi-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+      "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/table/node_modules/is-fullwidth-code-point": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/table/node_modules/string-width": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+      "dev": true,
+      "dependencies": {
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/table/node_modules/strip-ansi": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+      "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/temp": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/temp/-/temp-0.9.0.tgz",
+      "integrity": "sha512-YfUhPQCJoNQE5N+FJQcdPz63O3x3sdT4Xju69Gj4iZe0lBKOtnAMi0SLj9xKhGkcGhsxThvTJ/usxtFPo438zQ==",
+      "dev": true,
+      "engines": [
+        "node >=4.0.0"
+      ],
+      "dependencies": {
+        "rimraf": "~2.6.2"
+      }
+    },
+    "node_modules/text-table": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+      "dev": true
+    },
+    "node_modules/through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+      "dev": true
+    },
+    "node_modules/type-check": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+      "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+      "dev": true,
+      "dependencies": {
+        "prelude-ls": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+      "dev": true
+    },
+    "node_modules/underscore": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.1.tgz",
+      "integrity": "sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg=="
+    },
+    "node_modules/underscore-plus": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/underscore-plus/-/underscore-plus-1.7.0.tgz",
+      "integrity": "sha512-A3BEzkeicFLnr+U/Q3EyWwJAQPbA19mtZZ4h+lLq3ttm9kn8WC4R3YpuJZEXmWdLjYP47Zc8aLZm9kwdv+zzvA==",
+      "dependencies": {
+        "underscore": "^1.9.1"
+      }
+    },
+    "node_modules/uniq": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz",
+      "integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8=",
+      "dev": true
+    },
+    "node_modules/user-home": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
+      "integrity": "sha1-nHC/2Babwdy/SGBODwS4tJzenp8=",
+      "dev": true,
+      "dependencies": {
+        "os-homedir": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "dev": true
+    },
+    "node_modules/wordwrap": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+      "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    },
+    "node_modules/write": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
+      "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
+      "dev": true,
+      "dependencies": {
+        "mkdirp": "^0.5.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/xtend": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4"
+      }
+    }
+  },
   "dependencies": {
     "acorn": {
       "version": "5.7.4",
@@ -41,7 +1718,8 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-1.5.1.tgz",
       "integrity": "sha1-MU3QpLM2j609/NxU7eYXG4htrzw=",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "ansi-escapes": {
       "version": "1.4.0",
@@ -75,66 +1753,6 @@
       "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
       "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
       "dev": true
-    },
-    "atom-jasmine3-test-runner": {
-      "version": "5.1.8",
-      "resolved": "https://registry.npmjs.org/atom-jasmine3-test-runner/-/atom-jasmine3-test-runner-5.1.8.tgz",
-      "integrity": "sha512-TOc/JgA0EmyQ6lc1RjK1Tsv1/tNvUJiH0GqK/zbKUTRER38rhsEv6WGMsF6pq9AOgX4KVjrUeuAgMFlz+FbLBQ==",
-      "dev": true,
-      "requires": {
-        "etch": "^0.14.1",
-        "find-parent-dir": "^0.3.0",
-        "fs-plus": "3.1.1",
-        "glob": "^7.1.6",
-        "grim": "^2.0.3",
-        "jasmine": "~3.6.3",
-        "jasmine-local-storage": "^1.1.1",
-        "jasmine-pass": "^1.1.0",
-        "jasmine-should-fail": "^1.1.7",
-        "jasmine-unspy": "^1.1.0",
-        "jasmine2-atom-matchers": "^1.1.7",
-        "jasmine2-focused": "^1.1.1",
-        "jasmine2-json": "^1.1.1",
-        "jasmine2-tagged": "^1.1.1",
-        "semver": "^7.3.2",
-        "temp": "^0.9.4",
-        "underscore-plus": "^1.7.0"
-      },
-      "dependencies": {
-        "glob": {
-          "version": "7.1.6",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
-          "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
-          "dev": true,
-          "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          }
-        },
-        "grim": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/grim/-/grim-2.0.3.tgz",
-          "integrity": "sha512-FM20Ump11qYLK9k9DbL8yzVpy+YBieya1JG15OeH8s+KbHq8kL4SdwRtURwIUHniSxb24EoBUpwKfFjGNVi4/Q==",
-          "dev": true,
-          "requires": {
-            "event-kit": "^2.0.0"
-          }
-        },
-        "temp": {
-          "version": "0.9.4",
-          "resolved": "https://registry.npmjs.org/temp/-/temp-0.9.4.tgz",
-          "integrity": "sha512-yYrrsWnrXMcdsnu/7YMYAofM1ktpL5By7vZhf15CrXijWWrEYZks5AXBudalfSWJLlnen/QUJUB5aoB0kqZUGA==",
-          "dev": true,
-          "requires": {
-            "mkdirp": "^0.5.1",
-            "rimraf": "~2.6.2"
-          }
-        }
-      }
     },
     "atom-slick": {
       "version": "2.0.0",
@@ -470,13 +2088,15 @@
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-6.2.1.tgz",
       "integrity": "sha1-06aKr8cZFjnn7kQec0hzkCY1QpI=",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "eslint-config-standard-jsx": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/eslint-config-standard-jsx/-/eslint-config-standard-jsx-3.2.0.tgz",
       "integrity": "sha1-wkDibtkZoRpCqk3oBZRys4Jo1iA=",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "eslint-plugin-promise": {
       "version": "3.4.2",
@@ -498,7 +2118,8 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/eslint-plugin-standard/-/eslint-plugin-standard-2.0.1.tgz",
       "integrity": "sha1-NYlpn/nJF/LCX3apFmh/ZBw2n/M=",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "espree": {
       "version": "3.5.4",
@@ -535,12 +2156,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
       "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
-      "dev": true
-    },
-    "etch": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/etch/-/etch-0.14.1.tgz",
-      "integrity": "sha512-+IwqSDBhaQFMUHJu4L/ir0dhDoW5IIihg4Z9lzsIxxne8V0PlSg0gnk2STaKWjGJQnDR4cxpA+a/dORX9kycTA==",
       "dev": true
     },
     "event-emitter": {
@@ -589,12 +2204,6 @@
         "flat-cache": "^1.2.1",
         "object-assign": "^4.0.1"
       }
-    },
-    "find-parent-dir": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/find-parent-dir/-/find-parent-dir-0.3.0.tgz",
-      "integrity": "sha1-M8RLQpqysvBkYpnF+fcY83b/jVQ=",
-      "dev": true
     },
     "find-root": {
       "version": "1.1.0",
@@ -820,96 +2429,6 @@
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
       "dev": true
     },
-    "jasmine": {
-      "version": "3.6.3",
-      "resolved": "https://registry.npmjs.org/jasmine/-/jasmine-3.6.3.tgz",
-      "integrity": "sha512-Th91zHsbsALWjDUIiU5d/W5zaYQsZFMPTdeNmi8GivZPmAaUAK8MblSG3yQI4VMGC/abF2us7ex60NH1AAIMTA==",
-      "dev": true,
-      "requires": {
-        "glob": "^7.1.6",
-        "jasmine-core": "~3.6.0"
-      },
-      "dependencies": {
-        "glob": {
-          "version": "7.1.6",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
-          "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
-          "dev": true,
-          "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          }
-        }
-      }
-    },
-    "jasmine-core": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-3.6.0.tgz",
-      "integrity": "sha512-8uQYa7zJN8hq9z+g8z1bqCfdC8eoDAeVnM5sfqs7KHv9/ifoJ500m018fpFc7RDaO6SWCLCXwo/wPSNcdYTgcw==",
-      "dev": true
-    },
-    "jasmine-local-storage": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/jasmine-local-storage/-/jasmine-local-storage-1.1.1.tgz",
-      "integrity": "sha512-GBqtas3l8SBo39NwjbHuzWhQhgHabq/mVVDabGvKLUXRFH8GtPy4jPKRIMDLWC+q7S+q4M6pIY4OHoVuU8hsCQ==",
-      "dev": true
-    },
-    "jasmine-pass": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/jasmine-pass/-/jasmine-pass-1.1.0.tgz",
-      "integrity": "sha512-gtsHtIj1zNS/90REIpyDH2HRSW7vFwKMau5A2hcfL/RsSwUiKAS8EdOY1Z67m8giyaUMe7I8O7SzJF2oevCX0A==",
-      "dev": true
-    },
-    "jasmine-should-fail": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/jasmine-should-fail/-/jasmine-should-fail-1.1.7.tgz",
-      "integrity": "sha512-MNtae0/NUAU0OknPcM4cTA04JEXmxMH0+hqZxBjdt4+8LvDqm+oYIQcY70OqpRwVhTTcAyG7HxiPw/4AGlxfgw==",
-      "dev": true
-    },
-    "jasmine-unspy": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/jasmine-unspy/-/jasmine-unspy-1.1.1.tgz",
-      "integrity": "sha512-hTuMR1ju73BkGG8OCY6ObtimVBqnyThwUuclXW81lOiT/pyBt2W5nZtNAd8N7jzUfjQDd7+m+0DPm5Ecf6T2Pw==",
-      "dev": true
-    },
-    "jasmine2-atom-matchers": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/jasmine2-atom-matchers/-/jasmine2-atom-matchers-1.1.7.tgz",
-      "integrity": "sha512-9xJALLB9suLGxSkN063Wf0aJGTwrTgmbjgX+dr4gqBKqh5CWkdyB4pyET8rJkX2UYAQJuw0tKCgbwccNJ0CuHA==",
-      "dev": true,
-      "requires": {
-        "jquery": "^3.5.1",
-        "underscore-plus": "^1.7.0"
-      }
-    },
-    "jasmine2-focused": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/jasmine2-focused/-/jasmine2-focused-1.1.1.tgz",
-      "integrity": "sha512-2NnQD+Lwqu/0RIVentOiDtdsjhP/4jJooG88rQC3A6lKHxnm2d9Q/wGbQBDZlIA7bDUrQpuHZ6d2A/lACLwfhQ==",
-      "dev": true
-    },
-    "jasmine2-json": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/jasmine2-json/-/jasmine2-json-1.1.1.tgz",
-      "integrity": "sha512-D8dFHVDsDZpqgYK4eR3SYkMXypRjK0MpnHzVkO38ByXe7R3QaZDsoRt3Kh4rqI1U4iq9hkxHuKr+gy+OzuL+8g==",
-      "dev": true
-    },
-    "jasmine2-tagged": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/jasmine2-tagged/-/jasmine2-tagged-1.1.1.tgz",
-      "integrity": "sha512-PK/83f9hBI6R/gGZ8zEYHt4OUtZu3xpcoUFICMBVsdbbanrhCCNC3EkWldIQgvuSHaUMhVptXAihWjNJI3uiRw==",
-      "dev": true
-    },
-    "jquery": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.5.1.tgz",
-      "integrity": "sha512-XwIBPqcMn57FxfT+Go5pzySnm4KWkT1Tv7gjrpT1srtf8Weynl6R273VJ5GjkRb51IzMp5nbaPjJXMWeju2MKg==",
-      "dev": true
-    },
     "js-tokens": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
@@ -968,15 +2487,6 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
       "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
       "dev": true
-    },
-    "lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
-      "requires": {
-        "yallist": "^4.0.0"
-      }
     },
     "marked": {
       "version": "4.0.10",
@@ -1284,15 +2794,6 @@
         "atom-slick": "^2"
       }
     },
-    "semver": {
-      "version": "7.3.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
-      "integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
-      "dev": true,
-      "requires": {
-        "lru-cache": "^6.0.0"
-      }
-    },
     "shelljs": {
       "version": "0.7.8",
       "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.8.tgz",
@@ -1358,6 +2859,15 @@
         }
       }
     },
+    "string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
     "string-width": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
@@ -1367,15 +2877,6 @@
         "code-point-at": "^1.0.0",
         "is-fullwidth-code-point": "^1.0.0",
         "strip-ansi": "^3.0.0"
-      }
-    },
-    "string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "~5.1.0"
       }
     },
     "strip-ansi": {
@@ -1547,12 +3048,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
       "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
-      "dev": true
-    },
-    "yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true
     }
   }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "underscore-plus": "^1.6.6"
   },
   "devDependencies": {
-    "atom-jasmine3-test-runner": "^5.1.8",
     "coffeelint": "^1.9.7",
     "fs-plus": ">=2.4.0",
     "standard": "^8.3.0",
@@ -255,6 +254,5 @@
     "ignore": [
       "**/spec/fixtures/**"
     ]
-  },
-  "atomTestRunner": "./spec/custom-runner"
+  }
 }

--- a/spec/autocomplete-manager-autosave-spec.js
+++ b/spec/autocomplete-manager-autosave-spec.js
@@ -72,7 +72,7 @@ return sort(Array.apply(this, arguments));
       })
     }
 
-    spyOn(autocompleteManager, 'displaySuggestions').and.callFake((suggestions, options) => {
+    spyOn(autocompleteManager, 'displaySuggestions').andCallFake((suggestions, options) => {
       displaySuggestions(suggestions, options)
       for (const resolve of suggestionsPromises) {
         resolve()

--- a/spec/autocomplete-manager-integration-spec.js
+++ b/spec/autocomplete-manager-integration-spec.js
@@ -84,7 +84,7 @@ describe('Autocomplete Manager', () => {
 
       expect(provider.onDidInsertSuggestion).toHaveBeenCalled();
 
-      ({editor, triggerPosition, suggestion} = provider.onDidInsertSuggestion.calls.mostRecent().args[0])
+      ({editor, triggerPosition, suggestion} = provider.onDidInsertSuggestion.mostRecentCall.args[0])
       expect(editor).toBe(editor)
       expect(triggerPosition).toEqual([0, 1])
       expect(suggestion.text).toBe('ab')
@@ -232,14 +232,14 @@ describe('Autocomplete Manager', () => {
       })
 
       it('caches the blacklist result', async () => {
-        spyOn(path, 'basename').and.callThrough()
+        spyOn(path, 'basename').andCallThrough()
 
         editor.insertText('a')
         editor.insertText('b')
         editor.insertText('c')
 
         await waitForAutocompleteToDisappear(editor)
-        expect(path.basename.calls.count()).toBe(1)
+        expect(path.basename.callCount).toBe(1)
       })
 
       it('shows suggestions when the path is changed to not match the blacklist', async () => {
@@ -2032,8 +2032,8 @@ defm`
       })
 
       ;({ autocompleteManager } = mainModule)
-      spyOn(autocompleteManager, 'findSuggestions').and.callThrough()
-      spyOn(autocompleteManager, 'displaySuggestions').and.callThrough()
+      spyOn(autocompleteManager, 'findSuggestions').andCallThrough()
+      spyOn(autocompleteManager, 'displaySuggestions').andCallThrough()
     })
 
     describe('when strict matching is used', () => {
@@ -2048,7 +2048,7 @@ defm`
         editor.insertText('o')
 
         await conditionPromise(
-          () => autocompleteManager.findSuggestions.calls.count() === 1
+          () => autocompleteManager.findSuggestions.callCount === 1
         )
       })
     })
@@ -2194,7 +2194,7 @@ defm`
 
       it('does not update the suggestion list while composition is in progress', async () => {
         const activeElement = editorView.querySelector('input')
-        spyOn(autocompleteManager.suggestionList, 'changeItems').and.callThrough()
+        spyOn(autocompleteManager.suggestionList, 'changeItems').andCallThrough()
 
         editor.moveToBottom()
         editor.insertText('q')
@@ -2203,26 +2203,26 @@ defm`
         await waitForAutocomplete(editor)
 
         expect(autocompleteManager.suggestionList.changeItems).toHaveBeenCalled()
-        expect(autocompleteManager.suggestionList.changeItems.calls.mostRecent().args[0][0].text).toBe('quicksort')
-        autocompleteManager.suggestionList.changeItems.calls.reset()
+        expect(autocompleteManager.suggestionList.changeItems.mostRecentCall.args[0][0].text).toBe('quicksort')
+        autocompleteManager.suggestionList.changeItems.callCount = 0
 
         activeElement.dispatchEvent(buildIMECompositionEvent('compositionstart', {data: 'i', target: activeElement}))
         triggerAutocompletion(editor, false, 'i')
 
         await conditionPromise(() =>
-          autocompleteManager.suggestionList.changeItems.calls.count() > 0
+          autocompleteManager.suggestionList.changeItems.callCount > 0
         )
 
-        expect(autocompleteManager.suggestionList.changeItems.calls.mostRecent().args[0][0].text).toBe('quicksort')
-        autocompleteManager.suggestionList.changeItems.calls.reset()
+        expect(autocompleteManager.suggestionList.changeItems.mostRecentCall.args[0][0].text).toBe('quicksort')
+        autocompleteManager.suggestionList.changeItems.callCount = 0
 
         activeElement.dispatchEvent(buildIMECompositionEvent('compositionupdate', {data: 'ï', target: activeElement}))
         editor.selectLeft()
 
         editor.insertText('ï')
 
-        const initialCallCount = autocompleteManager.suggestionList.changeItems.calls.count()
-        await conditionPromise(() => autocompleteManager.suggestionList.changeItems.calls.count() > initialCallCount)
+        const initialCallCount = autocompleteManager.suggestionList.changeItems.callCount
+        await conditionPromise(() => autocompleteManager.suggestionList.changeItems.callCount > initialCallCount)
 
         expect(autocompleteManager.suggestionList.changeItems).toHaveBeenCalledWith(null)
         activeElement.dispatchEvent(buildIMECompositionEvent('compositionend', {target: activeElement}))

--- a/spec/autocomplete-manager-integration-spec.js
+++ b/spec/autocomplete-manager-integration-spec.js
@@ -152,7 +152,7 @@ describe('Autocomplete Manager', () => {
     })
 
     it('it hides the suggestion list when the user keeps typing', async () => {
-      spyOn(provider, 'getSuggestions').and.callFake(({prefix}) => ['acd', 'ade'].filter((t) => t.startsWith(prefix)).map((t) => ({text: t})))
+      spyOn(provider, 'getSuggestions').andCallFake(({prefix}) => ['acd', 'ade'].filter((t) => t.startsWith(prefix)).map((t) => ({text: t})))
 
       expect(editorView.querySelector('.autocomplete-plus')).not.toExist()
 
@@ -207,7 +207,7 @@ describe('Autocomplete Manager', () => {
     })
 
     it('does not display empty suggestions', async () => {
-      spyOn(provider, 'getSuggestions').and.callFake(() => {
+      spyOn(provider, 'getSuggestions').andCallFake(() => {
         let list = ['ab', '', 'abcd', null]
         return (list.map((text) => ({text})))
       })
@@ -279,7 +279,7 @@ describe('Autocomplete Manager', () => {
       })
 
       it('does not display empty suggestions', async () => {
-        spyOn(provider, 'getSuggestions').and.callFake(() => {
+        spyOn(provider, 'getSuggestions').andCallFake(() => {
           let list = ['ab', '', 'abcd', null]
           return (list.map((text) => ({text})))
         })
@@ -295,7 +295,7 @@ describe('Autocomplete Manager', () => {
 
     describe('when the type option has a space in it', () =>
       it('does not display empty suggestions', async () => {
-        spyOn(provider, 'getSuggestions').and.callFake(() => [{text: 'ab', type: 'local function'}, {text: 'abc', type: ' another ~ function   '}])
+        spyOn(provider, 'getSuggestions').andCallFake(() => [{text: 'ab', type: 'local function'}, {text: 'abc', type: ' another ~ function   '}])
 
         expect(editorView.querySelector('.autocomplete-plus')).not.toExist()
         editor.insertText('a')
@@ -311,7 +311,7 @@ describe('Autocomplete Manager', () => {
 
     describe('when the className option has a space in it', () =>
       it('does not display empty suggestions', async () => {
-        spyOn(provider, 'getSuggestions').and.callFake(() => [{text: 'ab', className: 'local function'}, {text: 'abc', className: ' another  ~ function   '}])
+        spyOn(provider, 'getSuggestions').andCallFake(() => [{text: 'ab', className: 'local function'}, {text: 'abc', className: ' another  ~ function   '}])
 
         expect(editorView.querySelector('.autocomplete-plus')).not.toExist()
         editor.insertText('a')
@@ -326,7 +326,7 @@ describe('Autocomplete Manager', () => {
 
     describe('when multiple cursors are defined', () => {
       it('autocompletes word when there is only a prefix', async () => {
-        spyOn(provider, 'getSuggestions').and.callFake(() => [{text: 'shift'}])
+        spyOn(provider, 'getSuggestions').andCallFake(() => [{text: 'shift'}])
 
         editor.getBuffer().insert([0, 0], 's:extra:s')
         editor.setSelectedBufferRanges([[[0, 1], [0, 1]], [[0, 9], [0, 9]]])
@@ -356,7 +356,7 @@ describe('Autocomplete Manager', () => {
       })
 
       it('cancels the autocomplete when text differs between cursors', async () => {
-        spyOn(provider, 'getSuggestions').and.callFake(() => [])
+        spyOn(provider, 'getSuggestions').andCallFake(() => [])
 
         editor.getBuffer().insert([0, 0], 's:extra:a')
         editor.setCursorBufferPosition([0, 1])
@@ -456,7 +456,7 @@ describe('Autocomplete Manager', () => {
 
         editor.setText('var something = abc')
         editor.setCursorBufferPosition([0, 10000])
-        spyOn(provider, 'getSuggestions').and.callFake((options) => {
+        spyOn(provider, 'getSuggestions').andCallFake((options) => {
           prefix = options.prefix
           resolveSuggestionsPromise()
           return []
@@ -721,7 +721,7 @@ describe('Autocomplete Manager', () => {
 
       describe('when a suggestion description is specified', () => {
         it('shows the maxVisibleSuggestions in the suggestion popup, but with extra height for the description', async () => {
-          spyOn(provider, 'getSuggestions').and.callFake(() => {
+          spyOn(provider, 'getSuggestions').andCallFake(() => {
             let list = ['ab', 'abc', 'abcd', 'abcde']
             return (list.map((text) => ({text, description: `${text} yeah ok`})))
           })
@@ -741,7 +741,7 @@ describe('Autocomplete Manager', () => {
         })
 
         it('parses markdown in the description', async () => {
-          spyOn(provider, 'getSuggestions').and.callFake(({prefix}) => {
+          spyOn(provider, 'getSuggestions').andCallFake(({prefix}) => {
             let list = [
               {text: 'ab', descriptionMarkdown: '**mmmmmmmmmmmmmmmmmmmmmmmmmm**'},
               {text: 'abc', descriptionMarkdown: '**mmmmmmmmmmmmmmmmmmmmmm**'},
@@ -772,7 +772,7 @@ describe('Autocomplete Manager', () => {
 
         it('adjusts the width when the description changes', async () => {
           let listWidth = null
-          spyOn(provider, 'getSuggestions').and.callFake(({prefix}) => {
+          spyOn(provider, 'getSuggestions').andCallFake(({prefix}) => {
             let list = [
               {text: 'ab', description: 'mmmmmmmmmmmmmmmmmmmmmmmmmm'},
               {text: 'abc', description: 'mmmmmmmmmmmmmmmmmmmmmm'},
@@ -875,7 +875,7 @@ describe('Autocomplete Manager', () => {
 
     describe('when match.snippet is used', () => {
       beforeEach(() => {
-        spyOn(provider, 'getSuggestions').and.callFake(({prefix}) => {
+        spyOn(provider, 'getSuggestions').andCallFake(({prefix}) => {
           let list = ['method(${1:something})', 'method2(${1:something})', 'method3(${1:something})', 'namespace\\\\method4(${1:something})']
           return (list.map((snippet) => ({snippet, replacementPrefix: prefix})))
         })
@@ -929,7 +929,7 @@ describe('Autocomplete Manager', () => {
 
     describe('when the matched prefix is highlighted', () => {
       it('highlights the prefix of the word in the suggestion list', async () => {
-        spyOn(provider, 'getSuggestions').and.callFake(({prefix}) => [{text: 'items', replacementPrefix: prefix}])
+        spyOn(provider, 'getSuggestions').andCallFake(({prefix}) => [{text: 'items', replacementPrefix: prefix}])
 
         expect(editorView.querySelector('.autocomplete-plus')).not.toExist()
 
@@ -952,7 +952,7 @@ describe('Autocomplete Manager', () => {
       })
 
       it('highlights repeated characters in the prefix', async () => {
-        spyOn(provider, 'getSuggestions').and.callFake(({prefix}) => [{text: 'apply', replacementPrefix: prefix}])
+        spyOn(provider, 'getSuggestions').andCallFake(({prefix}) => [{text: 'apply', replacementPrefix: prefix}])
 
         expect(editorView.querySelector('.autocomplete-plus')).not.toExist()
 
@@ -976,7 +976,7 @@ describe('Autocomplete Manager', () => {
 
       describe('when the prefix does not match the word', () => {
         it('does not render any character-match spans', async () => {
-          spyOn(provider, 'getSuggestions').and.callFake(({prefix}) => [{text: 'omgnope', replacementPrefix: prefix}])
+          spyOn(provider, 'getSuggestions').andCallFake(({prefix}) => [{text: 'omgnope', replacementPrefix: prefix}])
 
           editor.moveToBottom()
           editor.insertText('x')
@@ -997,7 +997,7 @@ describe('Autocomplete Manager', () => {
           beforeEach(() => atom.packages.activatePackage('snippets'))
 
           it('does not highlight the snippet html; ref issue 301', async () => {
-            spyOn(provider, 'getSuggestions').and.callFake(() => [{snippet: 'ab(${1:c})c'}])
+            spyOn(provider, 'getSuggestions').andCallFake(() => [{snippet: 'ab(${1:c})c'}])
 
             editor.moveToBottom()
             editor.insertText('c')
@@ -1011,7 +1011,7 @@ describe('Autocomplete Manager', () => {
           })
 
           it('does not highlight the snippet html when highlight beginning of the word', async () => {
-            spyOn(provider, 'getSuggestions').and.callFake(() => [{snippet: 'abcde(${1:e}, ${1:f})f'}])
+            spyOn(provider, 'getSuggestions').andCallFake(() => [{snippet: 'abcde(${1:e}, ${1:f})f'}])
 
             editor.moveToBottom()
             editor.insertText('c')
@@ -1036,7 +1036,7 @@ describe('Autocomplete Manager', () => {
 
     describe('when a replacementPrefix is not specified', () => {
       beforeEach(() => {
-        spyOn(provider, 'getSuggestions').and.callFake(() => [{text: 'something'}])
+        spyOn(provider, 'getSuggestions').andCallFake(() => [{text: 'something'}])
       })
 
       it('replaces with the default input prefix', async () => {
@@ -1101,7 +1101,7 @@ describe('Autocomplete Manager', () => {
       let suggestion = {text: 'something'}
 
       beforeEach(() => {
-        spyOn(provider, 'getSuggestions').and.callFake(() => [suggestion])
+        spyOn(provider, 'getSuggestions').andCallFake(() => [suggestion])
       })
 
       it('adds isPrefixModified the first time suggestion is shown', async () => {
@@ -1135,7 +1135,7 @@ describe('Autocomplete Manager', () => {
       })
 
       it('places the suggestion list at the cursor', async () => {
-        spyOn(provider, 'getSuggestions').and.callFake(options => [{text: 'ab', leftLabel: 'void'}, {text: 'abc', leftLabel: 'void'}])
+        spyOn(provider, 'getSuggestions').andCallFake(options => [{text: 'ab', leftLabel: 'void'}, {text: 'abc', leftLabel: 'void'}])
 
         editor.insertText('omghey ab')
         triggerAutocompletion(editor, false, 'c')
@@ -1150,7 +1150,7 @@ describe('Autocomplete Manager', () => {
       })
 
       it('closes the suggestion list if the user keeps typing', async () => {
-        spyOn(provider, 'getSuggestions').and.callFake(({prefix}) => ['acd', 'ade'].filter((t) => t.startsWith(prefix)).map((t) => ({text: t})))
+        spyOn(provider, 'getSuggestions').andCallFake(({prefix}) => ['acd', 'ade'].filter((t) => t.startsWith(prefix)).map((t) => ({text: t})))
 
         expect(editorView.querySelector('.autocomplete-plus')).not.toExist()
 
@@ -1166,7 +1166,7 @@ describe('Autocomplete Manager', () => {
       })
 
       it('keeps the suggestion list visible if the user keeps typing', async () => {
-        spyOn(provider, 'getSuggestions').and.callFake(({prefix}) => ['acd', 'ade'].filter((t) => t.startsWith(prefix)).map((t) => ({text: t})))
+        spyOn(provider, 'getSuggestions').andCallFake(({prefix}) => ['acd', 'ade'].filter((t) => t.startsWith(prefix)).map((t) => ({text: t})))
 
         expect(editorView.querySelector('.autocomplete-plus')).not.toExist()
 
@@ -1196,7 +1196,7 @@ describe('Autocomplete Manager', () => {
       })
 
       it('displays the suggestion list taking into account the passed back replacementPrefix', async () => {
-        spyOn(provider, 'getSuggestions').and.callFake(options => [{text: '::before', replacementPrefix: '::', leftLabel: 'void'}])
+        spyOn(provider, 'getSuggestions').andCallFake(options => [{text: '::before', replacementPrefix: '::', leftLabel: 'void'}])
 
         editor.insertText('xxxxxxxxxxx ab:')
         triggerAutocompletion(editor, false, ':')
@@ -1208,7 +1208,7 @@ describe('Autocomplete Manager', () => {
       })
 
       it('displays the suggestion list with a negative margin to align the prefix with the word-container', async () => {
-        spyOn(provider, 'getSuggestions').and.callFake(options => [{text: 'ab', leftLabel: 'void'}, {text: 'abc', leftLabel: 'void'}])
+        spyOn(provider, 'getSuggestions').andCallFake(options => [{text: 'ab', leftLabel: 'void'}, {text: 'abc', leftLabel: 'void'}])
 
         editor.insertText('omghey ab')
         triggerAutocompletion(editor, false, 'c')
@@ -1308,7 +1308,7 @@ describe('Autocomplete Manager', () => {
 
       describe('when the replacementPrefix is empty', () => {
         beforeEach(() => {
-          spyOn(provider, 'getSuggestions').and.callFake(() => [{text: 'someMethod()', replacementPrefix: ''}])
+          spyOn(provider, 'getSuggestions').andCallFake(() => [{text: 'someMethod()', replacementPrefix: ''}])
         })
 
         it('will insert the text without replacing anything', async () => {
@@ -1422,7 +1422,7 @@ describe('Autocomplete Manager', () => {
 
       describe('when a suffix of the replacement matches the text after the cursor', () => {
         it('overwrites that existing text with the replacement', async () => {
-          spyOn(provider, 'getSuggestions').and.callFake(() => [
+          spyOn(provider, 'getSuggestions').andCallFake(() => [
             {text: 'oneomgtwo', replacementPrefix: 'one'}
           ])
 
@@ -1438,7 +1438,7 @@ describe('Autocomplete Manager', () => {
         })
 
         it('does not overwrite any text if the "consumeSuffix" setting is disabled', async () => {
-          spyOn(provider, 'getSuggestions').and.callFake(() => [
+          spyOn(provider, 'getSuggestions').andCallFake(() => [
             {text: 'oneomgtwo', replacementPrefix: 'one'}
           ])
 
@@ -1456,7 +1456,7 @@ describe('Autocomplete Manager', () => {
         })
 
         it('does not overwrite non-word characters', async () => {
-          spyOn(provider, 'getSuggestions').and.callFake(() => [
+          spyOn(provider, 'getSuggestions').andCallFake(() => [
             {text: 'oneomgtwo()', replacementPrefix: 'one'}
           ])
 
@@ -1474,7 +1474,7 @@ describe('Autocomplete Manager', () => {
 
       describe('when the cursor suffix does not match the replacement', () => {
         beforeEach(() =>
-          spyOn(provider, 'getSuggestions').and.callFake(() => [{text: 'oneomgTwo', replacementPrefix: 'one'}]))
+          spyOn(provider, 'getSuggestions').andCallFake(() => [{text: 'oneomgTwo', replacementPrefix: 'one'}]))
 
         it('replaces the suffix with the replacement', async () => {
           editor.setText('ontwothree')
@@ -1525,7 +1525,7 @@ describe('Autocomplete Manager', () => {
       })
 
       it('accepts the suggestion if there is one', async () => {
-        spyOn(provider, 'getSuggestions').and.callFake(options => [{text: 'omgok'}])
+        spyOn(provider, 'getSuggestions').andCallFake(options => [{text: 'omgok'}])
 
         triggerAutocompletion(editor)
         await timeoutPromise(100)
@@ -1539,7 +1539,7 @@ describe('Autocomplete Manager', () => {
       })
 
       it('does not accept the suggestion if the event detail is activatedManually: false', async () => {
-        spyOn(provider, 'getSuggestions').and.callFake(options => [{text: 'omgok'}])
+        spyOn(provider, 'getSuggestions').andCallFake(options => [{text: 'omgok'}])
 
         triggerAutocompletion(editor)
         await timeoutPromise(100)
@@ -1550,7 +1550,7 @@ describe('Autocomplete Manager', () => {
       })
 
       it('does not accept the suggestion if auto-confirm single suggestion is disabled', async () => {
-        spyOn(provider, 'getSuggestions').and.callFake(options => [{text: 'omgok'}])
+        spyOn(provider, 'getSuggestions').andCallFake(options => [{text: 'omgok'}])
 
         triggerAutocompletion(editor)
         await timeoutPromise(100)
@@ -1563,7 +1563,7 @@ describe('Autocomplete Manager', () => {
 
       it('includes the correct value for activatedManually when explicitly triggered', async () => {
         let receivedOptions
-        spyOn(provider, 'getSuggestions').and.callFake((options) => {
+        spyOn(provider, 'getSuggestions').andCallFake((options) => {
           receivedOptions = options
           return [{text: 'omgok'}, {text: 'ahgok'}]
         })
@@ -1580,7 +1580,7 @@ describe('Autocomplete Manager', () => {
       })
 
       it('does not auto-accept a single suggestion when filtering', async () => {
-        spyOn(provider, 'getSuggestions').and.callFake(({prefix}) => {
+        spyOn(provider, 'getSuggestions').andCallFake(({prefix}) => {
           let list = []
           if ('a'.indexOf(prefix) === 0) { list.push('a') }
           if ('abc'.indexOf(prefix) === 0) { list.push('abc') }
@@ -1601,7 +1601,7 @@ describe('Autocomplete Manager', () => {
     describe('when the replacementPrefix doesnt match the actual prefix', () => {
       describe('when snippets are not used', () => {
         beforeEach(() => {
-          spyOn(provider, 'getSuggestions').and.callFake(() => [{text: 'something', replacementPrefix: 'bcm'}])
+          spyOn(provider, 'getSuggestions').andCallFake(() => [{text: 'something', replacementPrefix: 'bcm'}])
         })
 
         it('only replaces the suggestion at cursors whos prefix matches the replacementPrefix', async () => {
@@ -1625,7 +1625,7 @@ defm`
 
       describe('when snippets are used', () => {
         beforeEach(async () => {
-          spyOn(provider, 'getSuggestions').and.callFake(() => [{snippet: 'ok(${1:omg})', replacementPrefix: 'bcm'}])
+          spyOn(provider, 'getSuggestions').andCallFake(() => [{snippet: 'ok(${1:omg})', replacementPrefix: 'bcm'}])
           await atom.packages.activatePackage('snippets')
         })
 
@@ -1651,7 +1651,7 @@ defm`
 
     describe('select-previous event', () => {
       it('selects the previous item in the list', async () => {
-        spyOn(provider, 'getSuggestions').and.callFake(() => [{text: 'ab'}, {text: 'abc'}, {text: 'abcd'}])
+        spyOn(provider, 'getSuggestions').andCallFake(() => [{text: 'ab'}, {text: 'abc'}, {text: 'abcd'}])
 
         triggerAutocompletion(editor, false, 'a')
         await waitForAutocomplete(editor)
@@ -1670,7 +1670,7 @@ defm`
       })
 
       it('closes the autocomplete when up arrow pressed when only one item displayed', async () => {
-        spyOn(provider, 'getSuggestions').and.callFake(({prefix}) =>
+        spyOn(provider, 'getSuggestions').andCallFake(({prefix}) =>
           [{text: 'quicksort'}, {text: 'quack'}].filter(val => val.text.startsWith(prefix))
         )
 
@@ -1700,7 +1700,7 @@ defm`
       })
 
       it('does not close the autocomplete when up arrow pressed with multiple items displayed but triggered on one item', async () => {
-        spyOn(provider, 'getSuggestions').and.callFake(({prefix}) =>
+        spyOn(provider, 'getSuggestions').andCallFake(({prefix}) =>
           [{text: 'quicksort'}, {text: 'quack'}].filter(val => val.text.startsWith(prefix))
         )
 
@@ -1745,7 +1745,7 @@ defm`
       })
 
       it('wraps to the first item when triggered at the end of the list', async () => {
-        spyOn(provider, 'getSuggestions').and.callFake(() => [{text: 'ab'}, {text: 'abc'}, {text: 'abcd'}])
+        spyOn(provider, 'getSuggestions').andCallFake(() => [{text: 'ab'}, {text: 'abc'}, {text: 'abcd'}])
 
         triggerAutocompletion(editor, false, 'a')
         await waitForAutocomplete(editor)
@@ -1772,7 +1772,7 @@ defm`
     describe('label rendering', () => {
       describe('when no labels are specified', () => {
         beforeEach(() => {
-          spyOn(provider, 'getSuggestions').and.callFake(options => [{text: 'ok'}])
+          spyOn(provider, 'getSuggestions').andCallFake(options => [{text: 'ok'}])
         })
 
         it('displays the text in the suggestion', async () => {
@@ -1790,7 +1790,7 @@ defm`
 
       describe('when `type` is specified', () => {
         beforeEach(() => {
-          spyOn(provider, 'getSuggestions').and.callFake(options => [{text: 'ok', type: 'omg'}])
+          spyOn(provider, 'getSuggestions').andCallFake(options => [{text: 'ok', type: 'omg'}])
         })
 
         it('displays an icon in the icon-container', async () => {
@@ -1804,7 +1804,7 @@ defm`
 
       describe('when the `type` specified has a default icon', () => {
         beforeEach(() => {
-          spyOn(provider, 'getSuggestions').and.callFake(options => [{text: 'ok', type: 'snippet'}])
+          spyOn(provider, 'getSuggestions').andCallFake(options => [{text: 'ok', type: 'snippet'}])
         })
 
         it('displays the default icon in the icon-container', async () => {
@@ -1818,7 +1818,7 @@ defm`
 
       describe('when `type` is an empty string', () => {
         beforeEach(() => {
-          spyOn(provider, 'getSuggestions').and.callFake(options => [{text: 'ok', type: ''}])
+          spyOn(provider, 'getSuggestions').andCallFake(options => [{text: 'ok', type: ''}])
         })
 
         it('does not display an icon in the icon-container', async () => {
@@ -1832,7 +1832,7 @@ defm`
 
       describe('when `iconHTML` is specified', () => {
         beforeEach(() => {
-          spyOn(provider, 'getSuggestions').and.callFake(options => [{text: 'ok', iconHTML: '<i class="omg"></i>'}])
+          spyOn(provider, 'getSuggestions').andCallFake(options => [{text: 'ok', iconHTML: '<i class="omg"></i>'}])
         })
 
         it('displays an icon in the icon-container', async () => {
@@ -1846,7 +1846,7 @@ defm`
 
       describe('when `iconHTML` is false', () => {
         beforeEach(() => {
-          spyOn(provider, 'getSuggestions').and.callFake(options => [{text: 'ok', type: 'something', iconHTML: false}])
+          spyOn(provider, 'getSuggestions').andCallFake(options => [{text: 'ok', type: 'something', iconHTML: false}])
         })
 
         it('does not display an icon in the icon-container', async () => {
@@ -1860,7 +1860,7 @@ defm`
 
       describe('when `iconHTML` is not a string and a `type` is specified', () => {
         beforeEach(() => {
-          spyOn(provider, 'getSuggestions').and.callFake(options => [{text: 'ok', type: 'something', iconHTML: true}])
+          spyOn(provider, 'getSuggestions').andCallFake(options => [{text: 'ok', type: 'something', iconHTML: true}])
         })
 
         it('displays the default icon in the icon-container', async () => {
@@ -1874,7 +1874,7 @@ defm`
 
       describe('when `iconHTML` is not a string and no type is specified', () => {
         beforeEach(() => {
-          spyOn(provider, 'getSuggestions').and.callFake(options => [{text: 'ok', iconHTML: true}])
+          spyOn(provider, 'getSuggestions').andCallFake(options => [{text: 'ok', iconHTML: true}])
         })
 
         it('it does not display an icon', async () => {
@@ -1888,7 +1888,7 @@ defm`
 
       describe('when `rightLabel` is specified', () => {
         beforeEach(() => {
-          spyOn(provider, 'getSuggestions').and.callFake(options => [{text: 'ok', rightLabel: '<i class="something">sometext</i>'}])
+          spyOn(provider, 'getSuggestions').andCallFake(options => [{text: 'ok', rightLabel: '<i class="something">sometext</i>'}])
         })
 
         it('displays the text in the suggestion', async () => {
@@ -1902,7 +1902,7 @@ defm`
 
       describe('when `rightLabelHTML` is specified', () => {
         beforeEach(() => {
-          spyOn(provider, 'getSuggestions').and.callFake(options => [{text: 'ok', rightLabelHTML: '<i class="something">sometext</i>'}])
+          spyOn(provider, 'getSuggestions').andCallFake(options => [{text: 'ok', rightLabelHTML: '<i class="something">sometext</i>'}])
         })
 
         it('displays the text in the suggestion', async () => {
@@ -1916,7 +1916,7 @@ defm`
 
       describe('when `leftLabel` is specified', () => {
         beforeEach(() => {
-          spyOn(provider, 'getSuggestions').and.callFake(options => [{text: 'ok', leftLabel: '<i class="something">sometext</i>'}])
+          spyOn(provider, 'getSuggestions').andCallFake(options => [{text: 'ok', leftLabel: '<i class="something">sometext</i>'}])
         })
 
         it('displays the text in the suggestion', async () => {
@@ -1930,7 +1930,7 @@ defm`
 
       describe('when `leftLabelHTML` is specified', () => {
         beforeEach(() => {
-          spyOn(provider, 'getSuggestions').and.callFake(options => [{text: 'ok', leftLabelHTML: '<i class="something">sometext</i>'}])
+          spyOn(provider, 'getSuggestions').andCallFake(options => [{text: 'ok', leftLabelHTML: '<i class="something">sometext</i>'}])
         })
 
         it('displays the text in the suggestion', async () => {
@@ -1945,7 +1945,7 @@ defm`
 
     describe('when clicking in the suggestion list', () => {
       beforeEach(() => {
-        spyOn(provider, 'getSuggestions').and.callFake(() => {
+        spyOn(provider, 'getSuggestions').andCallFake(() => {
           let list = ['ab', 'abc', 'abcd', 'abcde']
           return (list.map((text) => ({text, description: `${text} yeah ok`})))
         })
@@ -1990,7 +1990,7 @@ defm`
 
     describe('Keybind to navigate to descriptionMoreLink', () => {
       it('triggers openExternal on keybind if there is a description', async () => {
-        spyOn(provider, 'getSuggestions').and.callFake(() => [{text: 'ab', description: 'it is ab'}])
+        spyOn(provider, 'getSuggestions').andCallFake(() => [{text: 'ab', description: 'it is ab'}])
         let shell = require('electron').shell
         spyOn(shell, 'openExternal')
 
@@ -2003,7 +2003,7 @@ defm`
       })
 
       it('does not trigger openExternal on keybind if there is not a description', async () => {
-        spyOn(provider, 'getSuggestions').and.callFake(() => [{text: 'ab'}])
+        spyOn(provider, 'getSuggestions').andCallFake(() => [{text: 'ab'}])
         let shell = require('electron').shell
         spyOn(shell, 'openExternal')
 

--- a/spec/custom-runner.js
+++ b/spec/custom-runner.js
@@ -1,8 +1,0 @@
-// const { createRunner } = require('atom-jasmine3-test-runner')
-//
-// const options = {
-//   specHelper: true,
-//   silentInstallation: true
-// }
-//
-// module.exports = createRunner(options)

--- a/spec/custom-runner.js
+++ b/spec/custom-runner.js
@@ -1,8 +1,8 @@
-const { createRunner } = require('atom-jasmine3-test-runner')
-
-const options = {
-  specHelper: true,
-  silentInstallation: true
-}
-
-module.exports = createRunner(options)
+// const { createRunner } = require('atom-jasmine3-test-runner')
+//
+// const options = {
+//   specHelper: true,
+//   silentInstallation: true
+// }
+//
+// module.exports = createRunner(options)

--- a/spec/provider-api-legacy-spec.js
+++ b/spec/provider-api-legacy-spec.js
@@ -203,7 +203,7 @@ describe('Provider API Legacy', () => {
       triggerAutocompletion(editor, true, 'o')
       await waitForAutocomplete(editor)
 
-      let args = testProvider.requestHandler.calls.mostRecent().args[0]
+      let args = testProvider.requestHandler.mostRecentCall.args[0]
       expect(args.editor).toBeDefined()
       expect(args.buffer).toBeDefined()
       expect(args.cursor).toBeDefined()

--- a/spec/provider-api-spec.js
+++ b/spec/provider-api-spec.js
@@ -98,7 +98,7 @@ describe('Provider API', () => {
         triggerAutocompletion(editor, true, 'o')
         await waitForAutocomplete(editor)
 
-        let args = testProvider.getSuggestions.calls.mostRecent().args[0]
+        let args = testProvider.getSuggestions.mostRecentCall.args[0]
         expect(args.editor).toBeDefined()
         expect(args.bufferPosition).toBeDefined()
         expect(args.scopeDescriptor).toBeDefined()

--- a/spec/spec-helper.js
+++ b/spec/spec-helper.js
@@ -1,8 +1,8 @@
 /* eslint-env jasmine */
 
 beforeEach(() => {
-  spyOn(atom.views, 'readDocument').and.callFake(fn => fn())
-  spyOn(atom.views, 'updateDocument').and.callFake(fn => fn())
+  spyOn(atom.views, 'readDocument').andCallFake(fn => fn())
+  spyOn(atom.views, 'updateDocument').andCallFake(fn => fn())
   atom.config.set('autocomplete-plus.minimumWordLength', 1)
   atom.config.set('autocomplete-plus.suggestionListFollows', 'Word')
   atom.config.set('autocomplete-plus.useCoreMovementCommands', true)

--- a/spec/suggestion-list-element-spec.js
+++ b/spec/suggestion-list-element-spec.js
@@ -296,7 +296,7 @@ describe('Suggestion List Element', () => {
     })
 
     it('cycles to the last element in the suggestion list when the current selection is at the start of the list', () => {
-      spyOn(suggestionListElement, 'visibleItems').and.returnValue(['a', 'b', 'c', 'd', 'e'])
+      spyOn(suggestionListElement, 'visibleItems').andReturn(['a', 'b', 'c', 'd', 'e'])
       spyOn(suggestionListElement, 'setSelectedIndex')
 
       suggestionListElement.moveSelectionUp()
@@ -307,7 +307,7 @@ describe('Suggestion List Element', () => {
 
   describe('moveSelectionDown', () => {
     it('increases the selected index if the current selection is not at the end of the list', () => {
-      spyOn(suggestionListElement, 'visibleItems').and.returnValue(['a', 'b', 'c', 'd', 'e'])
+      spyOn(suggestionListElement, 'visibleItems').andReturn(['a', 'b', 'c', 'd', 'e'])
       spyOn(suggestionListElement, 'setSelectedIndex')
       suggestionListElement.selectedIndex = 3
 
@@ -325,7 +325,7 @@ describe('Suggestion List Element', () => {
       }
       spyOn(model.activeEditor, 'moveDown')
       spyOn(model, 'cancel')
-      spyOn(suggestionListElement, 'visibleItems').and.returnValue(['a', 'b', 'c', 'd', 'e'])
+      spyOn(suggestionListElement, 'visibleItems').andReturn(['a', 'b', 'c', 'd', 'e'])
 
       suggestionListElement.model = model
       suggestionListElement.selectedIndex = 4
@@ -338,7 +338,7 @@ describe('Suggestion List Element', () => {
     })
 
     it('cycles to the first element in the suggestion list when the current suggestion is at the end of the list', () => {
-      spyOn(suggestionListElement, 'visibleItems').and.returnValue(['a', 'b', 'c', 'd', 'e'])
+      spyOn(suggestionListElement, 'visibleItems').andReturn(['a', 'b', 'c', 'd', 'e'])
       spyOn(suggestionListElement, 'setSelectedIndex')
       suggestionListElement.selectedIndex = 4
 
@@ -381,7 +381,7 @@ describe('Suggestion List Element', () => {
       }
       spyOn(model.activeEditor, 'moveDown')
       spyOn(model, 'cancel')
-      spyOn(suggestionListElement, 'visibleItems').and.returnValue(['a'])
+      spyOn(suggestionListElement, 'visibleItems').andReturn(['a'])
 
       suggestionListElement.model = model
       suggestionListElement.moveToCancel = true
@@ -424,7 +424,7 @@ describe('Suggestion List Element', () => {
       }
       spyOn(model.activeEditor, 'moveToBottom')
       spyOn(model, 'cancel')
-      spyOn(suggestionListElement, 'visibleItems').and.returnValue(['a'])
+      spyOn(suggestionListElement, 'visibleItems').andReturn(['a'])
 
       suggestionListElement.model = model
       suggestionListElement.moveToCancel = true


### PR DESCRIPTION
Seems that Atom used to have a way to override the test runner.

Honestly, things are already _too complicated_ as they are now, so this PR makes autocomplete use the "normal" Pulsar test API. This basically changes:

```js
spy(...).and.callFake => spy(...).andCallFake
spy(...).calls.mostRecent => spy(...).mostRecentCall
```

etc, etc...